### PR TITLE
Drop APi server dependency

### DIFF
--- a/.github/workflows/jobs_deploy.yml
+++ b/.github/workflows/jobs_deploy.yml
@@ -49,16 +49,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
-    # Why do we do this here instead of in the docker image?
-    # It's because github package repository needs auth
-    # And we DO NOT want that auth inside the docker image
-    - name: Download dependencies
-      run: |
-        sbt compile
-        cp -r ~/.cache/coursier/v1/ ./coursier_cache
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build container
       run: |

--- a/.github/workflows/jobs_test.yml
+++ b/.github/workflows/jobs_test.yml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Build jar
       run: sbt assembly
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   
   containers:
     name: Confirm the container builds
@@ -37,16 +35,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    
-    # Why do we do this here instead of in the docker image?
-    # It's because github package repository needs auth
-    # And we DO NOT want that auth inside the docker image
-    - name: Download dependencies
-      run: |
-        sbt compile
-        cp -r ~/.cache/coursier/v1/ ./coursier_cache
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build container
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,6 @@ ENV SBT_HOME /usr/local/sbt
 ENV S3CMD_DIR $INSTALL_DIR/s3cmd-2.2.0
 ENV PATH ${PATH}:${SBT_HOME}/bin:$S3CMD_DIR
 
-# Needed because sbt will barf if we don't have one
-# Even though we aren't actually accessing the maven package repository
-ENV GITHUB_TOKEN=faketoken
-
 # Keep failing pipe command from reporting success to the build.
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
@@ -33,8 +29,3 @@ ENV SBT_VERSION 1.7.0
 RUN mkdir -p "$SBT_HOME" && \
     wget -qO - --no-check-certificate "https://github.com/sbt/sbt/releases/download/v$SBT_VERSION/sbt-$SBT_VERSION.tgz" |  tar xz -C $INSTALL_DIR && \
     echo "- with sbt $SBT_VERSION" >> /root/.built
-
-# Cache dependencies
-COPY . .
-COPY coursier_cache /root/.cache/coursier/v1/
-RUN sbt assembly

--- a/build.sbt
+++ b/build.sbt
@@ -32,10 +32,6 @@ lazy val compilerOptions = Seq(
 )
 
 lazy val settings = Seq(
-  githubTokenSource := TokenSource.Or(
-    TokenSource.Environment("GITHUB_TOKEN"),
-    TokenSource.GitConfig("github.token")
-  ),
   releaseVersionBump := sbtrelease.Version.Bump.Bugfix,
   publishConfiguration := publishConfiguration.value.withOverwrite(true),
   publishLocalConfiguration := publishLocalConfiguration.value.withOverwrite(
@@ -48,7 +44,6 @@ lazy val settings = Seq(
 
 lazy val dependencies = Seq(
   Dependencies.scalaTest % Test,
-  Dependencies.content,
   Dependencies.sparkCore % "provided",
   Dependencies.sparkSql % "provided",
   Dependencies.sparkXml,
@@ -71,8 +66,6 @@ lazy val forcedDependencies = Seq(
 
 lazy val assemblySettings = Seq(
   organization := "io.fluentlabs",
-  githubOwner := "fluent-labs",
-  githubRepository := "jobs",
   // Used for building jobs fat jars
   assembly / assemblyJarName := name.value + ".jar",
   assembly / assemblyMergeStrategy := {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,6 @@ object Dependencies {
   val sparkVersion = "3.3.0"
 
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.12"
-  val content = "io.fluentlabs" %% "content" % "1.0.17"
 
   val sparkCore = "org.apache.spark" %% "spark-core" % sparkVersion
   val sparkSql = "org.apache.spark" %% "spark-sql" % sparkVersion

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,4 +8,3 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "1.1.1")
 // Publishing
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 addSbtPlugin("com.github.sbt" % "sbt-git" % "2.0.0")
-addSbtPlugin("com.codecommit" % "sbt-github-packages" % "0.5.3")

--- a/src/main/scala/io/fluentlabs/jobs/definitions/DefinitionSource.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/DefinitionSource.scala
@@ -1,0 +1,12 @@
+package io.fluentlabs.jobs.definitions
+
+object DefinitionSource extends Enumeration {
+  type DefinitionSource = Value
+
+  val CEDICT: Value = Value("CEDICT")
+  val WIKTIONARY_CHINESE: Value = Value("WIKTIONARY_CHINESE")
+  val WIKTIONARY_DANISH: Value = Value("WIKTIONARY_DANISH")
+  val WIKTIONARY_ENGLISH: Value = Value("WIKTIONARY_ENGLISH")
+  val WIKTIONARY_SIMPLE_ENGLISH: Value = Value("WIKTIONARY_SIMPLE_ENGLISH")
+  val WIKTIONARY_SPANISH: Value = Value("WIKTIONARY_SPANISH")
+}

--- a/src/main/scala/io/fluentlabs/jobs/definitions/DefinitionsParsingJob.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/DefinitionsParsingJob.scala
@@ -1,15 +1,14 @@
 package io.fluentlabs.jobs.definitions
 
-import io.fluentlabs.content.types.external.definition.DefinitionEntry
-import io.fluentlabs.content.types.internal.definition.DefinitionSource.DefinitionSource
 import io.fluentlabs.jobs.SparkSessionBuilder
+import io.fluentlabs.jobs.definitions.DefinitionSource.DefinitionSource
 import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.sql.{Dataset, SparkSession}
 
 import scala.reflect.runtime.universe.TypeTag
 
 // Typetag needed to tell spark how to encode as a dataset
-abstract class DefinitionsParsingJob[T <: DefinitionEntry: TypeTag](
+abstract class DefinitionsParsingJob[T](
     s3BasePath: String,
     defaultBackupFileName: String,
     source: DefinitionSource

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/CEDICT.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/CEDICT.scala
@@ -1,12 +1,18 @@
 package io.fluentlabs.jobs.definitions.source
 
-import io.fluentlabs.content.types.external.definition.cedict.CEDICTDefinitionEntry
-import io.fluentlabs.content.types.internal.definition.DefinitionSource
-import io.fluentlabs.jobs.definitions.DefinitionsParsingJob
+import io.fluentlabs.jobs.definitions.{DefinitionSource, DefinitionsParsingJob}
 import org.apache.spark.sql.{Dataset, SparkSession}
 
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
+
+case class CEDICTDefinitionEntry(
+    subdefinitions: List[String],
+    pinyin: String,
+    simplified: String,
+    traditional: String,
+    token: String
+)
 
 object CEDICT
     extends DefinitionsParsingJob[CEDICTDefinitionEntry](

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionary.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionary.scala
@@ -12,12 +12,11 @@ import org.apache.spark.sql.{Column, DataFrame, Dataset, SparkSession}
 import scala.collection.immutable.ArraySeq
 
 case class SimpleWiktionaryDefinitionEntry(
-    pronunciation: String,
+    pronunciation: List[String],
     tag: Option[String],
     examples: Option[List[String]],
     token: String,
     definition: String,
-    tagRaw: String,
     ipa: String,
     subdefinitions: List[String],
     // Nice extras
@@ -26,7 +25,6 @@ case class SimpleWiktionaryDefinitionEntry(
     homophones: List[String],
     notes: List[String],
     otherSpellings: List[String],
-    pronunciationRaw: List[String],
     related: List[String],
     synonyms: List[String],
     usage: List[String]
@@ -155,7 +153,7 @@ object SimpleWiktionary
         Wiktionary.regexp_extract_all(subdefinitionsRegex, 1)(col("definition"))
       )
       .withColumn(
-        "examplesRaw",
+        "examples",
         Wiktionary.regexp_extract_all(examplesRegex, 1)(col("definition"))
       )
 
@@ -175,7 +173,7 @@ object SimpleWiktionary
       .filter("col not like ''")
       .drop(partOfSpeechCols)
       .withColumnRenamed("col", "definition")
-      .withColumn("tagRaw", mapPartOfSpeech(col("pos")))
+      .withColumn("tag", mapPartOfSpeech(col("pos")))
       .drop("pos")
 
   val subsectionsInverted: Map[String, Set[String]] = subsectionMap

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionary.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionary.scala
@@ -161,7 +161,6 @@ object SimpleWiktionary
 
     addOptionalSections(splitDefinitions)
       .drop("text")
-      .withColumnRenamed("pronunciation", "pronunciationRaw")
       .as[SimpleWiktionaryDefinitionEntry]
   }
 

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionary.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionary.scala
@@ -1,8 +1,6 @@
 package io.fluentlabs.jobs.definitions.source
-
-import io.fluentlabs.content.types.external.definition.wiktionary.SimpleWiktionaryDefinitionEntry
-import io.fluentlabs.content.types.internal.definition.DefinitionSource
 import io.fluentlabs.jobs.definitions.{
+  DefinitionSource,
   DefinitionsParsingJob,
   Wiktionary,
   WiktionaryRawEntry
@@ -12,6 +10,27 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Column, DataFrame, Dataset, SparkSession}
 
 import scala.collection.immutable.ArraySeq
+
+case class SimpleWiktionaryDefinitionEntry(
+    pronunciation: String,
+    tag: Option[String],
+    examples: Option[List[String]],
+    token: String,
+    definition: String,
+    tagRaw: String,
+    ipa: String,
+    subdefinitions: List[String],
+    // Nice extras
+    antonyms: List[String],
+    homonyms: List[String],
+    homophones: List[String],
+    notes: List[String],
+    otherSpellings: List[String],
+    pronunciationRaw: List[String],
+    related: List[String],
+    synonyms: List[String],
+    usage: List[String]
+)
 
 object SimpleWiktionary
     extends DefinitionsParsingJob[SimpleWiktionaryDefinitionEntry](

--- a/src/test/scala/io/fluentlabs/jobs/definitions/source/CEDICTTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/source/CEDICTTest.scala
@@ -1,6 +1,5 @@
 package io.fluentlabs.jobs.definitions.source
 
-import io.fluentlabs.content.types.external.definition.cedict.CEDICTDefinitionEntry
 import org.scalatest.funspec.AnyFunSpec
 
 class CEDICTTest extends AnyFunSpec {

--- a/src/test/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionaryTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionaryTest.scala
@@ -1,7 +1,5 @@
 package io.fluentlabs.jobs.definitions.source
 
-import io.fluentlabs.content.types.external.definition.wiktionary.SimpleWiktionaryDefinitionEntry
-import io.fluentlabs.content.types.internal.word.PartOfSpeech
 import io.fluentlabs.jobs.definitions.WiktionaryRawEntry
 import org.apache.spark.sql.SparkSession
 import org.scalatest.funspec.AnyFunSpec
@@ -52,7 +50,7 @@ class SimpleWiktionaryTest extends AnyFunSpec {
 
     assert(entryParsed.token == "Is")
     assert(entryParsed.definition == definition)
-    assert(entryParsed.tag.contains(PartOfSpeech.VERB))
+    assert(entryParsed.tag.contains("verb"))
     assert(entryParsed.ipa == "ɪz")
     assert(
       entryParsed.subdefinitions === List(

--- a/src/test/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionaryTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionaryTest.scala
@@ -66,7 +66,9 @@ class SimpleWiktionaryTest extends AnyFunSpec {
       )
     )
     assert(
-      entryParsed.pronunciation === "=\n* {{IPA|/ɪz/}}\n* {{SAMPA|/Iz/}}\n* {{audio|en-us-is.ogg|Audio (US)}}\n\n"
+      entryParsed.pronunciation === List(
+        "=\n* {{IPA|/ɪz/}}\n* {{SAMPA|/Iz/}}\n* {{audio|en-us-is.ogg|Audio (US)}}\n\n"
+      )
     )
     assert(
       entryParsed.related === Array(

--- a/src/test/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionaryTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/source/SimpleWiktionaryTest.scala
@@ -50,7 +50,7 @@ class SimpleWiktionaryTest extends AnyFunSpec {
 
     assert(entryParsed.token == "Is")
     assert(entryParsed.definition == definition)
-    assert(entryParsed.tag.contains("verb"))
+    assert(entryParsed.tag.contains("Verb"))
     assert(entryParsed.ipa == "ɪz")
     assert(
       entryParsed.subdefinitions === List(


### PR DESCRIPTION
Coupling to the api server is expensive. It means we need to ship all our dependencies everywhere. It means we have to use github packages and manage another set of authentication tokens. And it means that we need to use the same versions of scala and libraries.

We also no longer need it. When definitions were stored by a schemaless service, sharing types meant avoiding errors. But if we store it in a relational database, schemas are enforced. 