### PR TITLE
Purge udfs from jobs

### DIFF
--- a/src/main/scala/io/fluentlabs/jobs/definitions/DatasetDefinitions.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/DatasetDefinitions.scala
@@ -7,7 +7,3 @@ package io.fluentlabs.jobs.definitions
 // Common
 case class WiktionaryRawEntry(id: Long, token: String, text: String)
 case class WiktionaryRawText(text: String)
-
-// Template job specific
-case class WiktionaryTemplateInstance(name: String, arguments: String)
-case class WiktionaryTemplate(name: String, count: BigInt)

--- a/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionarySectionFinder.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionarySectionFinder.scala
@@ -1,6 +1,8 @@
 package io.fluentlabs.jobs.definitions.analyze
 
+import io.fluentlabs.jobs.definitions.helpers.RegexHelper
 import io.fluentlabs.jobs.definitions.source.WiktionaryParser
+import org.apache.spark.sql.functions.{col, count, explode}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 // Use this when you want to know what kind of sections a backup has. Good for getting the rough structure of the dump
@@ -16,5 +18,23 @@ class WiktionarySectionFinder(source: String)
 
   def analyze(data: DataFrame, outputPath: String)(implicit
       spark: SparkSession
-  ): Unit = getHeadings(data, 1).write.csv(outputPath)
+  ): Unit = {
+    getHeadings(data, 1).write.csv(s"$outputPath/headings/level_one")
+    getHeadings(data, 2).write.csv(s"$outputPath/headings/level_two")
+    getHeadings(data, 3).write.csv(s"$outputPath/headings/level_three")
+    getHeadings(data, 4).write.csv(s"$outputPath/headings/level_four")
+  }
+
+  def getHeadings(data: DataFrame, level: Integer): DataFrame = {
+    data
+      .select(
+        explode(
+          RegexHelper.regexp_extract_all("text", headingRegex(level), 1)
+        ).alias("heading")
+      )
+      .groupBy("heading")
+      .agg(count("*").alias("count"))
+      .sort(col("count"))
+      .coalesce(1)
+  }
 }

--- a/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionarySectionFinder.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionarySectionFinder.scala
@@ -2,7 +2,13 @@ package io.fluentlabs.jobs.definitions.analyze
 
 import io.fluentlabs.jobs.definitions.helpers.RegexHelper
 import io.fluentlabs.jobs.definitions.source.WiktionaryParser
-import org.apache.spark.sql.functions.{col, count, explode}
+import org.apache.spark.sql.functions.{
+  col,
+  count,
+  explode,
+  regexp_extract,
+  split
+}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 // Use this when you want to know what kind of sections a backup has. Good for getting the rough structure of the dump
@@ -28,8 +34,11 @@ class WiktionarySectionFinder(source: String)
   def getHeadings(data: DataFrame, level: Integer): DataFrame = {
     data
       .select(
+        explode(split(col("text"), "\n")).alias("text")
+      )
+      .select(
         explode(
-          RegexHelper.regexp_extract_all("text", headingRegex(level), 1)
+          regexp_extract(col("text"), headingRegex(level), 1)
         ).alias("heading")
       )
       .groupBy("heading")

--- a/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionaryTemplateExtractor.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionaryTemplateExtractor.scala
@@ -5,6 +5,9 @@ import io.fluentlabs.jobs.definitions.source.WiktionaryParser
 import org.apache.spark.sql.functions.{arrays_zip, col, count, explode, first}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
+case class WiktionaryTemplateInstance(name: String, arguments: String)
+case class WiktionaryTemplate(name: String, count: BigInt, example: String)
+
 class WiktionaryTemplateExtractor(source: String)
     extends DefinitionsAnalysisJob(source)
     with WiktionaryParser {
@@ -20,9 +23,6 @@ class WiktionaryTemplateExtractor(source: String)
   ): Unit =
     extractTemplateCount(extractTemplateInstances(data)).write
       .csv(s"$outputPath/templates")
-
-  case class WiktionaryTemplateInstance(name: String, arguments: String)
-  case class WiktionaryTemplate(name: String, count: BigInt, example: String)
 
   def extractTemplateInstances(
       data: DataFrame

--- a/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionaryTemplateExtractor.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionaryTemplateExtractor.scala
@@ -2,10 +2,6 @@ package io.fluentlabs.jobs.definitions.analyze
 
 import io.fluentlabs.jobs.definitions.helpers.RegexHelper
 import io.fluentlabs.jobs.definitions.source.WiktionaryParser
-import io.fluentlabs.jobs.definitions.{
-  WiktionaryTemplate,
-  WiktionaryTemplateInstance
-}
 import org.apache.spark.sql.functions.{arrays_zip, col, count, explode, first}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 

--- a/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionaryTemplateExtractor.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/analyze/WiktionaryTemplateExtractor.scala
@@ -1,8 +1,11 @@
 package io.fluentlabs.jobs.definitions.analyze
 
 import io.fluentlabs.jobs.definitions.source.WiktionaryParser
-import io.fluentlabs.jobs.definitions.{WiktionaryTemplate, WiktionaryTemplateInstance}
-import org.apache.spark.sql.functions.{arrays_zip, col, element_at, explode, expr}
+import io.fluentlabs.jobs.definitions.{
+  WiktionaryTemplate,
+  WiktionaryTemplateInstance
+}
+import org.apache.spark.sql.functions.{arrays_zip, col, explode}
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 class WiktionaryTemplateExtractor(source: String)
@@ -43,8 +46,8 @@ class WiktionaryTemplateExtractor(source: String)
     import spark.implicits._
 
     data
-      .withColumn("name", expr(s"regexp_extract_all(text, $templateRegex, 1)"))
-      .withColumn("arguments", expr(s"regexp_extract_all(text, $templateRegex, 2)"))
+      .withColumn("name", regexp_extract_all("text", templateRegex, 1))
+      .withColumn("arguments", regexp_extract_all("text", templateRegex, 2))
       .select(
         explode(arrays_zip(col("name"), col("arguments")))
           .alias("template")

--- a/src/main/scala/io/fluentlabs/jobs/definitions/clean/SimpleWiktionaryCleaningJob.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/clean/SimpleWiktionaryCleaningJob.scala
@@ -140,16 +140,8 @@ object SimpleWiktionaryCleaningJob
     import spark.implicits._
     val splitDefinitions = splitWordsByPartOfSpeech(data)
       .withColumn("ipa", regexp_extract(col("text"), ipaRegex, 1))
-      .withColumn(
-        "subdefinitions",
-        regexp_extract_all(subdefinitionsRegex, 1)(
-          col("definition")
-        )
-      )
-      .withColumn(
-        "examples",
-        regexp_extract_all(examplesRegex, 1)(col("definition"))
-      )
+      .withColumn("subdefinitions", expr(s"regexp_extract_all(definition, $subdefinitionsRegex, 1)"))
+      .withColumn("examples", expr(s"regexp_extract_all(definition, $examplesRegex, 1)"))
 
     addOptionalSections(splitDefinitions)
       .drop("text")

--- a/src/main/scala/io/fluentlabs/jobs/definitions/clean/SimpleWiktionaryCleaningJob.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/clean/SimpleWiktionaryCleaningJob.scala
@@ -140,8 +140,14 @@ object SimpleWiktionaryCleaningJob
     import spark.implicits._
     val splitDefinitions = splitWordsByPartOfSpeech(data)
       .withColumn("ipa", regexp_extract(col("text"), ipaRegex, 1))
-      .withColumn("subdefinitions", expr(s"regexp_extract_all(definition, $subdefinitionsRegex, 1)"))
-      .withColumn("examples", expr(s"regexp_extract_all(definition, $examplesRegex, 1)"))
+      .withColumn(
+        "subdefinitions",
+        regexp_extract_all("definition", subdefinitionsRegex, 1)
+      )
+      .withColumn(
+        "examples",
+        regexp_extract_all("definition", examplesRegex, 1)
+      )
 
     addOptionalSections(splitDefinitions)
       .drop("text")

--- a/src/main/scala/io/fluentlabs/jobs/definitions/clean/SimpleWiktionaryCleaningJob.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/clean/SimpleWiktionaryCleaningJob.scala
@@ -1,5 +1,6 @@
 package io.fluentlabs.jobs.definitions.clean
 
+import io.fluentlabs.jobs.definitions.helpers.RegexHelper
 import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions._
@@ -142,11 +143,11 @@ object SimpleWiktionaryCleaningJob
       .withColumn("ipa", regexp_extract(col("text"), ipaRegex, 1))
       .withColumn(
         "subdefinitions",
-        regexp_extract_all("definition", subdefinitionsRegex, 1)
+        RegexHelper.regexp_extract_all("definition", subdefinitionsRegex, 1)
       )
       .withColumn(
         "examples",
-        regexp_extract_all("definition", examplesRegex, 1)
+        RegexHelper.regexp_extract_all("definition", examplesRegex, 1)
       )
 
     addOptionalSections(splitDefinitions)

--- a/src/main/scala/io/fluentlabs/jobs/definitions/helpers/RegexHelper.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/helpers/RegexHelper.scala
@@ -1,0 +1,55 @@
+package io.fluentlabs.jobs.definitions.helpers
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.expr
+
+object RegexHelper {
+  // Helpful escaped regex control characters
+  val backslash = "\\"
+  val leftBrace = "\\{"
+  val rightBrace = "\\}"
+  val openParenthesis = "\\("
+  val closeParenthesis = "\\)"
+  val pipe = "\\|"
+
+  /** Passing a regex to something that will consume backslash escape
+    * characters? Then you need to double escape it.
+    * @param regex
+    *   The regex to add escapes to.
+    * @return
+    *   A double escaped regex.
+    */
+  def doubleEscapeRegex(regex: String): String = {
+    // Needed because spark consumes the escape characters before passing to java.util.regex.Pattern
+    // And then the pattern is unescaped
+    regex
+      .replaceAll(leftBrace, backslash + leftBrace)
+      .replaceAll(rightBrace, backslash + rightBrace)
+      .replaceAll(openParenthesis, backslash + openParenthesis)
+      .replaceAll(closeParenthesis, backslash + closeParenthesis)
+  }
+
+  /** Get all instances of a regular expression in a column.
+    * @param column
+    *   The column to search
+    * @param regex
+    *   The regex pattern to use.
+    * @param index
+    *   The index of the capture group to pull out.
+    * @return
+    *   An array of strings: The selected capture group for each match.
+    */
+  def regexp_extract_all(
+      column: String,
+      regex: String,
+      index: Integer
+  ): Column =
+    expr(s"regexp_extract_all($column, '${doubleEscapeRegex(regex)}', $index)")
+
+  // String.repeat is only implemented on some JVMs
+  // Removing this has burned me twice.
+  // Run the unit tests in the docker container before trying to remove it again.
+  def repeat(token: String, count: Int): String = {
+    (0 until count).map(_ => token).mkString
+  }
+}

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
@@ -3,7 +3,7 @@ package io.fluentlabs.jobs.definitions.source
 import com.databricks.spark.xml.XmlDataFrameReader
 import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.{col, explode, regexp_extract, udf}
+import org.apache.spark.sql.functions.{col, explode, expr, regexp_extract, udf}
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 
 import scala.util.{Failure, Success, Try}
@@ -129,11 +129,15 @@ trait WiktionaryParser {
 
   // Section extraction down here
 
-  def extractSection(name: String): Column = regexp_extract(col("text"), sectionRegex(name), 1)
-  def extractSubSection(name: String): Column = regexp_extract(col("text"), subSectionRegex(name), 1)
+  def extractSection(name: String): Column =
+    regexp_extract(col("text"), sectionRegex(name), 1)
+  def extractSubSection(name: String): Column =
+    regexp_extract(col("text"), subSectionRegex(name), 1)
 
-  def extractSection(data: DataFrame, name: String): DataFrame = data.withColumn(name.toLowerCase(), extractSection(name))
-  def extractSubsection(data: DataFrame, name: String): DataFrame = data.withColumn(name.toLowerCase(), extractSubSection(name))
+  def extractSection(data: DataFrame, name: String): DataFrame =
+    data.withColumn(name.toLowerCase(), extractSection(name))
+  def extractSubsection(data: DataFrame, name: String): DataFrame =
+    data.withColumn(name.toLowerCase(), extractSubSection(name))
 
   def extractSections(
       data: DataFrame,
@@ -149,4 +153,10 @@ trait WiktionaryParser {
   ): DataFrame = {
     sections.foldLeft(data)((data, section) => extractSection(data, section))
   }
+
+  def regexp_extract_all(
+      column: String,
+      regex: String,
+      index: Integer
+  ): Column = expr(s"regexp_extract_all($column, '$regex', $index)")
 }

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
@@ -54,13 +54,15 @@ trait WiktionaryParser {
    * contents
    */
 
+  val beginningOfLine = "^"
   val caseInsensitiveFlag = "(?i)"
   val periodMatchesNewlineFlag = "(?s)"
   val oneOrMoreEqualsSign = "=+"
   val doubleEqualsSign = "=="
   val tripleEqualsSign = "==="
   val optionalWhiteSpace = " *"
-  val anythingButEqualsSign = "([^=]*)"
+  val anythingButEqualsSign = "[^=]*"
+  val anythingButEqualsSignCapturing = "([^=]*)"
   val lazyMatchAnything = "(.*?)"
   val spaceOrNewline = "[ |\n]+"
   val nextSection = s"(?>== *[A-Za-z0-9]+ *==$spaceOrNewline)"
@@ -77,10 +79,10 @@ trait WiktionaryParser {
     *   A regular expression letting you find all heading.
     */
   def headingRegex(level: Int): String =
-    RegexHelper.repeat(
+    beginningOfLine + RegexHelper.repeat(
       "=",
       level
-    ) + optionalWhiteSpace + anythingButEqualsSign + optionalWhiteSpace + RegexHelper
+    ) + optionalWhiteSpace + anythingButEqualsSignCapturing + optionalWhiteSpace + RegexHelper
       .repeat(
         "=",
         level

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
@@ -60,7 +60,7 @@ trait WiktionaryParser {
   val doubleEqualsSign = "=="
   val tripleEqualsSign = "==="
   val optionalWhiteSpace = " *"
-  val anythingButEqualsSign = "([^=])*"
+  val anythingButEqualsSign = "([^=]*)"
   val lazyMatchAnything = "(.*?)"
   val spaceOrNewline = "[ |\n]+"
   val nextSection = s"(?>== *[A-Za-z0-9]+ *==$spaceOrNewline)"

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
@@ -154,15 +154,4 @@ trait WiktionaryParser {
   ): DataFrame = {
     sections.foldLeft(data)((data, section) => extractSection(data, section))
   }
-
-  // Defined in SPARK-24884 but not released yet
-  val regexp_extract_all: (String, Int) => UserDefinedFunction =
-    (regex: String, captureGroupIndex: Int) =>
-      udf((input: String) => {
-        regex.r
-          .findAllIn(input)
-          .matchData
-          .map(m => m.group(captureGroupIndex))
-          .toArray
-      })
 }

--- a/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
+++ b/src/main/scala/io/fluentlabs/jobs/definitions/source/WiktionaryParser.scala
@@ -4,7 +4,7 @@ import com.databricks.spark.xml.XmlDataFrameReader
 import org.apache.log4j.{LogManager, Logger}
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import org.apache.spark.sql.functions.{col, explode, regexp_extract, udf}
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 
 import scala.util.{Failure, Success, Try}
 
@@ -129,11 +129,11 @@ trait WiktionaryParser {
 
   // Section extraction down here
 
-  def extractSection(data: DataFrame, name: String): DataFrame =
-    data.withColumn(
-      name.toLowerCase(),
-      regexp_extract(col("text"), sectionRegex(name), 1)
-    )
+  def extractSection(name: String): Column = regexp_extract(col("text"), sectionRegex(name), 1)
+  def extractSubSection(name: String): Column = regexp_extract(col("text"), subSectionRegex(name), 1)
+
+  def extractSection(data: DataFrame, name: String): DataFrame = data.withColumn(name.toLowerCase(), extractSection(name))
+  def extractSubsection(data: DataFrame, name: String): DataFrame = data.withColumn(name.toLowerCase(), extractSubSection(name))
 
   def extractSections(
       data: DataFrame,
@@ -143,11 +143,6 @@ trait WiktionaryParser {
       .foldLeft(data.toDF())((data, section) => extractSection(data, section))
   }
 
-  def extractSubsection(data: DataFrame, name: String): DataFrame =
-    data.withColumn(
-      name.toLowerCase(),
-      regexp_extract(col("text"), subSectionRegex(name), 1)
-    )
   def extractSubsections(
       data: DataFrame,
       sections: Array[String]

--- a/src/test/scala/io/fluentlabs/jobs/definitions/WiktionaryTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/WiktionaryTest.scala
@@ -67,18 +67,20 @@ class WiktionaryTest extends AnyFunSpec {
         |another garbage thing
         |== This is another heading ==
         |= heading level that doesn't exist =
-        |== uneven heading ===
         |=== uneven in a different way ==
         |""".stripMargin
 
     it("on the happy path") {
       val regex = Wiktionary.headingRegex(2)
       val items =
-        text.split("\n").flatMap(regex.r.findFirstMatchIn(_)).map(_.group(1))
+        text
+          .split("\n")
+          .flatMap(regex.r.findFirstMatchIn(_))
+          .map(_.group(1).trim)
       assert(
         items sameElements Array(
-          "this is a heading",
-          "this is another heading"
+          "This is a heading",
+          "This is another heading"
         )
       )
     }

--- a/src/test/scala/io/fluentlabs/jobs/definitions/WiktionaryTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/WiktionaryTest.scala
@@ -7,6 +7,20 @@ import org.scalatest.funspec.AnyFunSpec
 class WiktionaryTest extends AnyFunSpec {
   object Wiktionary extends WiktionaryParser
 
+  /*
+   * Nearly everything in the Wiktionary object is regex, we don't need to bring up an entire spark context to test.
+   * Let's keep these tests fast.
+   */
+  def regex_extract_all(
+      data: String,
+      pattern: String,
+      index: Integer
+  ): List[String] = {
+    val allMatches =
+      for (m <- pattern.r.findAllMatchIn(data)) yield m.group(index)
+    allMatches.toList
+  }
+
   describe("can correctly generate regexes") {
     it("can repeat a pattern") {
       assert(RegexHelper.repeat("=", 6) == "======")
@@ -47,51 +61,27 @@ class WiktionaryTest extends AnyFunSpec {
     }
   }
 
-  describe("can get headings") {
-    describe("for a single line") {
-      it("on the happy path") {
-        val test = "== Single heading =="
-        assert(Wiktionary.getHeadingFromLine(test, 2) == "single heading")
-      }
-      it("without error if there is no heading") {
-        assert(Wiktionary.getHeadingFromLine("", 2) == "")
-      }
-      it("and returns error if there is bad input") {
-        assert(
-          Wiktionary.getHeadingFromLine(
-            null,
-            2
-          ) == "ERROR" // scalastyle:ignore
-        )
-      }
-    }
+  describe("can generate regex patterns for headings") {
+    val text =
+      """== This is a heading ==
+        |another document item
+        |=== subheading that should be ignored ===
+        |another garbage thing
+        |== This is another heading ==
+        |= heading level that doesn't exist =
+        |== uneven heading ===
+        |=== uneven in a different way ==
+        |""".stripMargin
 
-    describe("for a document") {
-      it("on the happy path") {
-        val text =
-          """== This is a heading ==
-            |another document item
-            |=== subheading that should be ignored ===
-            |another garbage thing
-            |== This is another heading ==
-            |= heading level that doesn't exist =
-            |== uneven heading ===
-            |=== uneven in a different way ==
-            |""".stripMargin
-        assert(
-          Wiktionary.getHeadingsFromDocument(text, 2) sameElements Array(
-            "this is a heading",
-            "this is another heading"
-          )
+    it("on the happy path") {
+      val regex = Wiktionary.headingRegex(2)
+      val items = regex_extract_all(text, regex, 1)
+      assert(
+        items sameElements Array(
+          "this is a heading",
+          "this is another heading"
         )
-      }
-      it("and correctly handles bad input") {
-        assert(
-          Wiktionary
-            .getHeadingsFromDocument(null, 2) // scalastyle:ignore
-            .isEmpty
-        )
-      }
+      )
     }
   }
 }

--- a/src/test/scala/io/fluentlabs/jobs/definitions/WiktionaryTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/WiktionaryTest.scala
@@ -16,9 +16,7 @@ class WiktionaryTest extends AnyFunSpec {
       pattern: String,
       index: Integer
   ): List[String] = {
-    val allMatches =
-      for (m <- pattern.r.findAllMatchIn(data)) yield m.group(index)
-    allMatches.toList
+    pattern.r.findAllMatchIn(data).map(_.group(1)).toList
   }
 
   describe("can correctly generate regexes") {
@@ -75,7 +73,8 @@ class WiktionaryTest extends AnyFunSpec {
 
     it("on the happy path") {
       val regex = Wiktionary.headingRegex(2)
-      val items = regex_extract_all(text, regex, 1)
+      val items =
+        text.split("\n").flatMap(regex.r.findFirstMatchIn(_)).map(_.group(1))
       assert(
         items sameElements Array(
           "this is a heading",

--- a/src/test/scala/io/fluentlabs/jobs/definitions/WiktionaryTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/WiktionaryTest.scala
@@ -1,5 +1,6 @@
 package io.fluentlabs.jobs.definitions
 
+import io.fluentlabs.jobs.definitions.helpers.RegexHelper
 import io.fluentlabs.jobs.definitions.source.WiktionaryParser
 import org.scalatest.funspec.AnyFunSpec
 
@@ -8,7 +9,7 @@ class WiktionaryTest extends AnyFunSpec {
 
   describe("can correctly generate regexes") {
     it("can repeat a pattern") {
-      assert(Wiktionary.repeat("=", 6) == "======")
+      assert(RegexHelper.repeat("=", 6) == "======")
     }
 
     describe("for a heading of any size") {

--- a/src/test/scala/io/fluentlabs/jobs/definitions/analyze/TemplateExtractorTest.scala
+++ b/src/test/scala/io/fluentlabs/jobs/definitions/analyze/TemplateExtractorTest.scala
@@ -1,4 +1,4 @@
-package io.fluentlabs.jobs.definitions.exploration
+package io.fluentlabs.jobs.definitions.analyze
 
 import io.fluentlabs.jobs.definitions.WiktionaryRawText
 import io.fluentlabs.jobs.definitions.analyze.WiktionaryTemplateExtractor


### PR DESCRIPTION
UDFs are opaque to spark and can't be optimized. I mostly used them because I was new to spark. Let's do things the proper way now.