### PR TITLE
Make tests run locally

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,9 @@ lazy val forcedDependencies = Seq(
   Dependencies.jacksonScala,
   Dependencies.jacksonDatabind,
   Dependencies.jacksonCore,
+
+  // Sometimes an obsolete version of this gets pulled in at runtime.
+  // This breaks all spark runs.
   Dependencies.paranamer,
   Dependencies.paranamer % "runtime"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,9 @@ lazy val dependencies = Seq(
 lazy val forcedDependencies = Seq(
   Dependencies.jacksonScala,
   Dependencies.jacksonDatabind,
-  Dependencies.jacksonCore
+  Dependencies.jacksonCore,
+  Dependencies.paranamer,
+  Dependencies.paranamer % "runtime"
 )
 
 /*

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,4 +23,6 @@ object Dependencies {
     "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
   val jacksonCore =
     "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion
+
+  val paranamer = "com.thoughtworks.paranamer" % "paranamer" % "2.8"
 }


### PR DESCRIPTION
## Problem
An obsolete version of paranamer is being pulled in as a runtime dependency. This breaks tests running in intellij, but for some reason doesn't impact CI. It's not clear what will happen at runtime.

## Solution
Force using a newer version at runtime.